### PR TITLE
Migrate RTD conf

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,7 +1,7 @@
 version: 2
-
+build:
+  os: ubuntu-20.04
+  tools:
+    python: mambaforge-4.10
 conda:
-  environment: "env.yml"
-
-python:
-  version: "3.8"
+  environment: env.yml


### PR DESCRIPTION
Howdy! :wave:

I am @readthedocs-assistant and I am sending you this pull request to
upgrade the configuration of your Read the Docs project.
Your project will continue working whether or not you merge it,
but I recommended you to take it into consideration.

_*Note*: This tool is in beta phase. Don't hesitate to ping
@astrojuanlu and/or @humitos if you spot any problems._

The following migrators were applied:

- `UseBuildTools`: Migrate to `build.tools` configuration.

This uses the new base Docker image based on Ubuntu 20.04 introduced in October 2021    and picks an appropriate Python version for your project    (read [our blog post](https://blog.readthedocs.com/new-build-specification/)    for details).    Notice that now you can specify the Node.js, Rust, and Go versions as well.    *Note:* Some system dependencies are not preinstalled anymore,    so this might require manually adding them to `build.apt_packages`    (see [our    documentation](https://docs.readthedocs.io/en/stable/config-file/v2.html#build-apt-packages>)).


- `UseMamba`: Migrate to Mamba as a drop-in replacement for Conda.

Your project requested using Mamba instead of Conda for performance reasons.    Now this is included in your configuration    and you can change it without our intervention.



Happy documenting! :sparkles:
